### PR TITLE
Support idp_cert in place of idp_cert_fingerprint

### DIFF
--- a/lib/redmine_omniauth_saml.rb
+++ b/lib/redmine_omniauth_saml.rb
@@ -90,7 +90,6 @@ module Redmine::OmniAuthSAML
         [ :assertion_consumer_service_url,
           :issuer,
           :idp_sso_target_url,
-          :idp_cert_fingerprint,
           :name_identifier_format,
           :signout_url,
           :idp_slo_target_url,
@@ -98,6 +97,8 @@ module Redmine::OmniAuthSAML
           :attribute_mapping ].each do |k|
             raise "Redmine::OmiauthSAML.configure requires that saml.#{k} to be setted" unless saml[k]
           end
+
+        raise "Redmine::OmiauthSAML.configure requires either saml.idp_cert_fingerprint or saml.idp_cert to be set" unless saml[:idp_cert_fingerprint] || saml[:idp_cert]
 
         required_attribute_mapping.each do |k|
           raise "Redmine::OmiauthSAML.configure requires that saml.attribute_mapping[#{k}] to be setted" unless saml[:attribute_mapping][k]

--- a/sample-saml-initializers.rb
+++ b/sample-saml-initializers.rb
@@ -4,6 +4,8 @@ Redmine::OmniAuthSAML::Base.configure do |config|
     :issuer                         => "sso_issuer",                 # The issuer name
     :idp_sso_target_url             => "http://sso.desarrollo.unlp.edu.ar/saml2/idp/SSOService.php", # SSO login endpoint
     :idp_cert_fingerprint           => "certificate fingerprint", # SSO ssl certificate fingerprint
+    # Alternatively, specify the full certifiate:
+    #:idp_cert                       => "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
     :name_identifier_format         => "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
     :signout_url                    => "http://sso.example.com/saml2/idp/SingleLogoutService.php?ReturnTo=",
     :idp_slo_target_url             => "http://sso.example.com/saml2/idp/SingleLogoutService.php",


### PR DESCRIPTION
OmniAuth SAML allows specifying :idp_cert, which takes precedence over :idp_cert_fingerprint. This is useful since some providers only supply the cert, so one can just copy it directly without having to derive the fingerprint.