### PR TITLE
Only require the :mail attribute to be mapped

### DIFF
--- a/lib/redmine_omniauth_saml.rb
+++ b/lib/redmine_omniauth_saml.rb
@@ -80,10 +80,7 @@ module Redmine::OmniAuthSAML
       end
 
       def required_attribute_mapping
-        [ :login,
-          :firstname,
-          :lastname,
-          :mail ]
+        [ :mail ]
       end
 
       def validate_configuration!

--- a/sample-saml-initializers.rb
+++ b/sample-saml-initializers.rb
@@ -11,8 +11,6 @@ Redmine::OmniAuthSAML::Base.configure do |config|
     :attribute_mapping              => {
     # How will we map attributes from SSO to redmine attributes
       :login      => 'extra.raw_info.username',
-      :firstname  => 'extra.raw_info.first_name',
-      :lastname   => 'extra.raw_info.last_name',
       :mail       => 'extra.raw_info.email'
     }
   }


### PR DESCRIPTION
:login is only required when account creation is enabled; :firstname and :lastname are currently only used within the test suite but not in the core library