### PR TITLE
Various fixes to the sample initializer configuration

### DIFF
--- a/sample-saml-initializers.rb
+++ b/sample-saml-initializers.rb
@@ -1,7 +1,7 @@
 Redmine::OmniAuthSAML::Base.configure do |config|
   config.saml = {
-    :assertion_consumer_service_url => "http://redmine.example.com", # The redmine application hostname
-    :issuer                         => "sso_issuer",                 # The issuer name
+    :assertion_consumer_service_url => "http://redmine.example.com/auth/saml/callback", # OmniAuth callback URL
+    :issuer                         => "http://redmine.example.com",                    # The issuer name / entity ID. Must be an URI as per SAML 2.0 spec.
     :idp_sso_target_url             => "http://sso.desarrollo.unlp.edu.ar/saml2/idp/SSOService.php", # SSO login endpoint
     :idp_cert_fingerprint           => "certificate fingerprint", # SSO ssl certificate fingerprint
     :name_identifier_format         => "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",


### PR DESCRIPTION
:assertion_consumer_service_url must specify the OmniAuth callback URL
:issuer refers to the entity ID, which must be an URI as per section 8.3.6 Entity Identifier of the SAML 2.0 spec