### PR TITLE
Allow SSO attributes including dots

### DIFF
--- a/lib/redmine_omniauth_saml.rb
+++ b/lib/redmine_omniauth_saml.rb
@@ -64,7 +64,7 @@ module Redmine::OmniAuthSAML
         HashWithIndifferentAccess.new.tap do |h|
           required_attribute_mapping.each do |symbol|
             key = configured_saml[:attribute_mapping][symbol]
-            h[symbol] = key.split('.')                # Get an array with nested keys: name.first will return [name, first]
+            h[symbol] = key.split('|')                # Get an array with nested keys: name|first will return [name, first]
               .map {|x| [:[], x]}                     # Create pair elements being :[] symbol and the key
               .inject(omniauth) do |hash, params|     # For each key, apply method :[] with key as parameter
                 hash.send(*params)

--- a/sample-saml-initializers.rb
+++ b/sample-saml-initializers.rb
@@ -13,10 +13,15 @@ Redmine::OmniAuthSAML::Base.configure do |config|
     :name_identifier_value          => "mail", # Which redmine field is used as name_identifier_value for SAML logout
     :attribute_mapping              => {
     # How will we map attributes from SSO to redmine attributes
-      :login      => 'extra.raw_info.username',
-      :mail       => 'extra.raw_info.email',
-      :firstname  => 'extra.raw_info.firstname',
-      :lastname   => 'extra.raw_info.firstname'
+    # using either urn:oid:identifier, or friendly names, e.g.
+    # :mail       => 'extra|raw_info|urn:oid:0.9.2342.19200300.100.1.3'
+    # or
+    # :mail       => 'extra|raw_info|email'
+    # Edit defaults below to match your attributes
+      :login      => 'extra|raw_info|username',
+      :mail       => 'extra|raw_info|email',
+      :firstname  => 'extra|raw_info|firstname',
+      :lastname   => 'extra|raw_info|firstname'
     }
   }
 


### PR DESCRIPTION
This is a minor change to allow SSO attributes including dots, such as
`:mail => 'extra|raw_info|urn:oid:0.9.2342.19200300.100.1.3',`
Also added examples to sample-saml-initializers.rb to clarify how to configure.

This fixes #47.