### PR TITLE
Fixing broken SLS behaviour

### DIFF
--- a/lib/redmine_omniauth_saml.rb
+++ b/lib/redmine_omniauth_saml.rb
@@ -92,8 +92,6 @@ module Redmine::OmniAuthSAML
           :idp_sso_target_url,
           :idp_cert_fingerprint,
           :name_identifier_format,
-          :signout_url,
-          :idp_slo_target_url,
           :name_identifier_value,
           :attribute_mapping ].each do |k|
             raise "Redmine::OmiauthSAML.configure requires that saml.#{k} to be setted" unless saml[k]

--- a/lib/redmine_omniauth_saml/account_controller_patch.rb
+++ b/lib/redmine_omniauth_saml/account_controller_patch.rb
@@ -141,7 +141,7 @@ module Redmine::OmniAuthSAML
       if not settings[:signout_url]
         logger.info "SLO IdP Endpoint not found in settings, executing then a normal logout'"
         saml_logout_user
-        redirect home_path
+        redirect_to home_path
       else
 
         # Since we created a new SAML request, save the transaction_id

--- a/sample-saml-initializers.rb
+++ b/sample-saml-initializers.rb
@@ -1,12 +1,13 @@
 Redmine::OmniAuthSAML::Base.configure do |config|
   config.saml = {
-    :assertion_consumer_service_url => "http://redmine.example.com", # The redmine application hostname
-    :issuer                         => "sso_issuer",                 # The issuer name
+    :assertion_consumer_service_url => "https://redmine.example.com/auth/saml/callback", # The Redmine callback URL
+    :issuer                         => "https://redmine.example.com/auth/saml/metadata", # The entity ID / issuer name
     :idp_sso_target_url             => "http://sso.desarrollo.unlp.edu.ar/saml2/idp/SSOService.php", # SSO login endpoint
-    :idp_cert_fingerprint           => "certificate fingerprint", # SSO ssl certificate fingerprint
+    :idp_cert_fingerprint           => "certificate fingerprint", # SSO SSL certificate SHA-1 fingerprint
     :name_identifier_format         => "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
-    :signout_url                    => "http://sso.example.com/saml2/idp/SingleLogoutService.php?ReturnTo=",
-    :idp_slo_target_url             => "http://sso.example.com/saml2/idp/SingleLogoutService.php",
+    # SLS is not currently supported in the 3.x branch.
+    #:signout_url                    => "http://sso.example.com/saml2/idp/SingleLogoutService.php?ReturnTo=",
+    #:idp_slo_target_url             => "http://sso.example.com/saml2/idp/SingleLogoutService.php",
     :name_identifier_value          => "mail", # Which redmine field is used as name_identifier_value for SAML logout
     :attribute_mapping              => {
     # How will we map attributes from SSO to redmine attributes


### PR DESCRIPTION
The current redmine-3.0 branch requires `signout_url` and `idp_slo_target_url` but the callback path doesn't exist, SLS hasn't been implemented on the Redmine side in this branch. Looks like it was added for 4.x. Consequently, logout cannot succeed but you also cannot make Redmine use local logout (even though the code is actually there to do this).

So this PR does three things:
1. Stops `signout_url` and `idp_slo_target_url` being required for validation (SAML does not require them)
2. Fixes a little typo in the sign-out method which causes an error
3. Updates the sample documentation according to what I've discovered the settings should be

Hope this helps! :-)